### PR TITLE
added ctrl-slash/cmd-slash toggle commenting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,5 @@
+{
+    "comments": {
+        "lineComment": "%",
+    }
+}

--- a/package.json
+++ b/package.json
@@ -28,12 +28,20 @@
         "languages": [{
             "id": "george",
             "aliases": ["grg", "George"],
-            "extensions": [".grg"]
+            "extensions": [".grg"],
+            "configuration": "./language-configuration.json"
         }],
         "grammars": [{
             "language": "george",
             "scopeName": "source.grg",
             "path": "./syntaxes/george.tmLanguage"
+            
+        }],
+        "keybindings": [{
+            "key": "ctrl+/",
+            "mac": "cmd+/",
+            "command": "editor.action.commentLine",
+            "when": "editorTextFocus"
         }]
     },
     "scripts": {


### PR DESCRIPTION
Added the ability to comment/uncomment a line with keyboard shortcut (win) ctrl-slash or (mac) cmd-slash 